### PR TITLE
Add `libck` to images; update `configure` script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -237,17 +237,19 @@ RUN echo "deb http://deb.machinekit.io/debian $DISTRO_CODENAME main" > \
 ###################################################################
 # Machinekit:  Install dependency packages
 
+# Xenomai threads still supported on Jessie
+RUN if test $DISTRO_CODENAME = jessie -a -z "$SYS_ROOT"; then \
+        apt-get install -y libxenomai-dev \
+        && apt-get clean; \
+    fi
+
 ##############################
 # Machinekit:  Configure multistrap
 
 # Set up debian/control for `mk-build-deps`
 #     FIXME download parts from upstream
 ADD debian/ /tmp/debian/
-RUN if test $DISTRO_VER = 8; then \
-	MK_CROSS_BUILDER=1 /tmp/debian/configure -x; \
-    else \
-	MK_CROSS_BUILDER=1 /tmp/debian/configure; \
-    fi
+RUN MK_CROSS_BUILDER=1 /tmp/debian/configure
 
 # Directory for `mk-build-deps` apt repository
 RUN mkdir /tmp/debs && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -277,7 +277,8 @@ RUN if test $DISTRO_VER -le 9 -a $DEBIAN_ARCH = amd64; then \
 
 # Native arch:  Install build dependencies
 RUN if test -z "$SYS_ROOT"; then \
-        if test $DISTRO_VER -le 9; then \
+        apt-get update \
+        && if test $DISTRO_VER -le 9; then \
 	    apt-get install -y  -o Apt::Get::AllowUnauthenticated=true \
 		machinekit-build-deps; \
         else \

--- a/debian/configure
+++ b/debian/configure
@@ -73,7 +73,6 @@ usage() {
     test -z "$1" || echo "$1"
     echo "Usage:  $0 [ arg ... ]"
     echo "   arg:    function:"
-    echo "   -x      build Xenomai threads"
     echo "   -c      rewrite changelog to set package version from git commit"
     echo "   -s      create source tarball for non binary package builds"
     } >&2
@@ -98,37 +97,50 @@ HAVE_FLAVOR=false
 ## copy base templates into place
 
 ## situation at 20092018
+##
 ## python-gst1.0 backported to Jessie + Stretch
-## python-gtksourceview2 not available for Buster but is for Sid, meaning gladevcp widgets keep working.
-## python-pil and python-pil.imagegtk active for Sid replacing python-imaging and python-imaging-tk
-## however selecting python-imaging and python-imaging-tk in Stretch actually
-## results in python-pil and python-pil.imagegtk being installed, so will probably completely backport soon.
+##
+## python-gtksourceview2 not available for Buster but is for Sid,
+## meaning gladevcp widgets keep working.
+##
+## python-pil and python-pil.imagegtk active for Sid replacing
+## python-imaging and python-imaging-tk; however selecting
+## python-imaging and python-imaging-tk in Stretch actually results in
+## python-pil and python-pil.imagegtk being installed, so will
+## probably completely backport soon.
+##
+## 2019-06-21:
+## libck-dev too old in Jessie (and missing in i386 ?!?); missing in
+## Buster, but @ArcEye built packages for the MK repo
 
 case "$DISTRO_CODENAME" in
     buster)
-        : # Nothing
+        BUILD_DEPS+=", libck-dev"
         ;;
-    stretch|jessie|sid)
-        BUILD_DEPS+=", python-gtksourceview2"
+    jessie)
+        DEPS+=", python-gtksourceview2"
         ;;
     *)
-        BUILD_DEPS+=", python-gtksourceview2"
+        DEPS+=", python-gtksourceview2"
+        BUILD_DEPS+=", libck-dev"
         ;;
 esac
 
 # Configure Xenomai threads
 configure_xenomai() {
+    if ! dpkg-query -W | grep -q libxenomai-dev; then
+        echo "Not configuring build for Xenomai (no libxenomai-dev package)" >&2
+        return
+    fi
+
     echo "debian/control:  Adding xenomai threads configuration" >&2
-    # Be sure the -dev files only appear once
     BUILD_DEPS+=", libxenomai-dev"
     DEPS+=", xenomai-runtime"
-    echo "THREADS_XENOMAI = --with-xenomai" > rules.include
 }
 
 # read command line options
-while getopts xcsh ARG; do
+while getopts csh ARG; do
     case $ARG in
-    x) configure_xenomai ;;
     c) do_changelog ;;  # set new changelog with package versions from git
     s) do_source_tarball ;; # create tarball for non binary builds
     h) usage ;;
@@ -137,6 +149,7 @@ while getopts xcsh ARG; do
 done
 
 # Set control Build-Depends:
+configure_xenomai
 cp control.in control
 sed >control <control.in \
     -e "s/@BUILD_DEPS@/${BUILD_DEPS}/" \

--- a/debian/control.in
+++ b/debian/control.in
@@ -17,11 +17,9 @@ Build-Depends: debhelper (>= 6),
     libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
     python-protobuf (>= 2.4.1), libprotoc-dev (>= 2.4.1),
     python-simplejson, libtk-img, libboost-thread-dev,
-    python-pyftpdlib, tcl8.6-dev, tk8.6-dev, tcl-dev, libcgroup-dev,
-    python-gst-1.0 | python-gst-0.10,
-    python-imaging | python-pil,
     yapps2-runtime | python-yapps, yapps2,
-    python-imaging-tk | python-pil.imagegtk   @BUILD_DEPS@
+    python-pyftpdlib, tcl8.6-dev, tk8.6-dev, tcl-dev,
+    libcgroup-dev @BUILD_DEPS@
 Standards-Version: 2.1.0
 
 Package: machinekit
@@ -39,6 +37,9 @@ Depends: ${shlibs:Depends}, machinekit-rt-threads, tcl8.6, tk8.6,
     python-avahi, python-simplejson, python-pyftpdlib,
     python-pydot, xdot,
     tclreadline, bc, procps, psmisc, cgroup-tools,
+    python-gst-1.0 | python-gst0.10,
+    python-imaging | python-pil,
+    python-imaging-tk | python-pil.imagegtk,
     uuid-runtime @DEPS@
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which
@@ -49,8 +50,7 @@ Package: machinekit-dev
 Architecture: any
 Depends: make, g++, tcl8.6, tk8.6,
    ${shlibs:Depends}, ${misc:Depends},
-   machinekit (= ${binary:Version}),
-   yapps2-runtime
+   machinekit (= ${binary:Version})
 Section: libs
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which

--- a/multistrap-configs/jessie.conf
+++ b/multistrap-configs/jessie.conf
@@ -6,7 +6,7 @@ noauth=true
 unpack=true
 setupscript=/usr/share/multistrap/chroot.sh
 #aptsources=debian updates security backports
-bootstrap=machinekit-build-deps machinekit debian updates
+bootstrap=machinekit-build-deps machinekit debian
 
 [machinekit-build-deps]
 packages=machinekit-build-deps
@@ -26,10 +26,6 @@ suite=jessie
 source=http://ftp.debian.org/debian
 keyring=debian-archive-keyring
 suite=jessie
-
-[updates]
-source=http://ftp.debian.org/debian
-suite=jessie-updates
 
 [security]
 source=http://security.debian.org

--- a/multistrap-configs/jessie.conf
+++ b/multistrap-configs/jessie.conf
@@ -13,6 +13,8 @@ packages=machinekit-build-deps
 packages=build-essential
 # Run-time deps for testing
 packages=netcat-openbsd
+# Build Xenomai
+packages=libxenomai-dev
 
 source=file:/tmp/debs ./
 


### PR DESCRIPTION
Add `libck` to accommodate PR machinekit/machinekit-hal#222.  Pull in `debian/configure` script from the `mk-single-module-dir-zultron-rebase` branch in anticipation of its eventual merge.